### PR TITLE
Avoid naming conflict with functions from Windows headers.

### DIFF
--- a/src/devEMF.cpp
+++ b/src/devEMF.cpp
@@ -314,7 +314,7 @@ namespace EMFcb {
                   const pGEcontext gc, pDevDesc dd) {
             static_cast<CDevEMF*>(dd->deviceSpecific)->Line(x1,y1,x2,y2,gc);
         }
-        void Polyline(int n, double *x, double *y, 
+        void EMFcb_Polyline(int n, double *x, double *y,
                       const pGEcontext gc, pDevDesc dd) {
             static_cast<CDevEMF*>(dd->deviceSpecific)->Polyline(n,x,y, gc);
         }
@@ -331,7 +331,7 @@ namespace EMFcb {
                   const pGEcontext gc, pDevDesc dd) {
             static_cast<CDevEMF*>(dd->deviceSpecific)->Rect(x0,y0,x1,y1,gc);
         }
-        void Polygon(int n, double *x, double *y, 
+        void EMFcb_Polygon(int n, double *x, double *y,
                      const pGEcontext gc, pDevDesc dd) {
             static_cast<CDevEMF*>(dd->deviceSpecific)->Polygon(n,x,y,gc);
         }
@@ -957,8 +957,8 @@ Rboolean EMFDeviceDriver(pDevDesc dd, const char *filename,
 #if R_GE_version >= 8
     dd->path = EMFcb::Path;
 #endif
-    dd->polygon = EMFcb::Polygon;
-    dd->polyline = EMFcb::Polyline;
+    dd->polygon = EMFcb::EMFcb_Polygon;
+    dd->polyline = EMFcb::EMFcb_Polyline;
     dd->locator = EMFcb::Locator;
     dd->mode = EMFcb::Mode;
     dd->metricInfo = EMFcb::MetricInfo;


### PR DESCRIPTION
This fixes a naming conflict reported by LLVM 17 on Windows/aarch4:

```
evEMF.cpp:317:14: error: functions that differ only in their return type cannot be overloaded
  317 |         void Polyline(int n, double *x, double *y, 
      |         ~~~~ ^
.../aarch64-w64-mingw32.static.posix/include/wingdi.h:3468:28: note: previous declaration is here
 3468 |   WINGDIAPI WINBOOL WINAPI Polyline(HDC hdc,CONST POINT *apt,int cpt);
      |                            ^
devEMF.cpp:334:14: error: functions that differ only in their return type cannot be overloaded
  334 |         void Polygon(int n, double *x, double *y, 
      |         ~~~~ ^
.../aarch64-w64-mingw32.static.posix/include/wingdi.h:3467:28: note: previous declaration is here
 3467 |   WINGDIAPI WINBOOL WINAPI Polygon(HDC hdc,CONST POINT *apt,int cpt);

```